### PR TITLE
Use Yandex tracker client API to fetch history of the issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,12 @@ process:
 
 ## История изменений
 
+### 2022-06-20
+
+* [Refactor] Метод `PraktikTrackerClient.get_status_history()` переписан с
+  использованием штатного интерфейса клиента Яндекс-трекера.
+* [Refactor] Удален метод `PraktikTrackerClient.get_iteration_and_updated()`.
+
 ### 2022-05-24
 
 * Добавлен вывод свободных работ и отображение тикетов других ревьюверов.

--- a/prpr/main.py
+++ b/prpr/main.py
@@ -92,7 +92,7 @@ def main():
                 description=issue.description,
                 number=number,
                 course=extract_course(issue),
-                transitions=client.get_status_history(issue.key, issue.status.key),
+                transitions=client.get_status_history(issue),
             )
             for number, issue in enumerate(issues, 1)
         ]


### PR DESCRIPTION
Use Yandex tracker client API to fetch history of the issue instead of direct call to API endpoint by requests.